### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=Matej Sychra
 maintainer=Matej Sychra
 sentence=Arduino/ESP8266 wrapper for AES library with 128-bit CBC encryption
 paragraph=Arduino/ESP8266 wrapper for AES library with 128-bit CBC encryption
-category="Data Processing"
+category=Data Processing
 url=https://github.com/suculent/thinx-aes-lib
 architectures=esp8266,esp32


### PR DESCRIPTION
The previous category value caused the warning:

WARNING: Category '"Data Processing"' in library AESLib is not valid. Setting to 'Uncategorized'