### PR TITLE
Applied `const` specifiers throughout the library

### DIFF
--- a/src/AES.cpp
+++ b/src/AES.cpp
@@ -129,7 +129,7 @@ static byte is_box (byte x)
 }
 
 
-static void xor_block (byte * d, byte * s)
+static void xor_block (byte * d, const byte * s)
 {
   for (byte i = 0 ; i < N_BLOCK ; i += 4)
     {
@@ -140,7 +140,7 @@ static void xor_block (byte * d, byte * s)
     }
 }
 
-static void copy_and_key (byte * d, byte * s, byte * k)
+static void copy_and_key (byte * d, const byte * s, const byte * k)
 {
   for (byte i = 0 ; i < N_BLOCK ; i += 4)
     {
@@ -191,7 +191,7 @@ static void inv_shift_sub_rows (byte st[N_BLOCK])
 
 /* SUB COLUMNS PHASE */
 
-static void mix_sub_columns (byte dt[N_BLOCK], byte st[N_BLOCK])
+static void mix_sub_columns (byte dt[N_BLOCK], const byte st[N_BLOCK])
 {
   byte j = 5 ;
   byte k = 10 ;
@@ -211,7 +211,7 @@ static void mix_sub_columns (byte dt[N_BLOCK], byte st[N_BLOCK])
     }
 }
 
-static void inv_mix_sub_columns (byte dt[N_BLOCK], byte st[N_BLOCK])
+static void inv_mix_sub_columns (byte dt[N_BLOCK], const byte st[N_BLOCK])
 {
   for (byte i = 0 ; i < N_BLOCK ; i += N_COL)
     {
@@ -261,7 +261,7 @@ AES::AES(){
 
 /******************************************************************************/
 
-byte AES::set_key (byte key [], uint16_t keylen)
+byte AES::set_key (const byte key [], uint16_t keylen)
 {
   byte hi ;
   switch (keylen)
@@ -326,7 +326,7 @@ void AES::clean ()
 
 /******************************************************************************/
 
-void AES::copy_n_bytes (byte * d, byte * s, byte nn)
+void AES::copy_n_bytes (byte * d, const byte * s, byte nn)
 {
   while (nn >= 4)
     {
@@ -355,7 +355,7 @@ uint8_t AES::getrandom()
 
 /******************************************************************************/
 
-byte AES::encrypt (byte plain [N_BLOCK], byte cipher [N_BLOCK])
+byte AES::encrypt (const byte plain [N_BLOCK], byte cipher [N_BLOCK])
 {
   if (round)
     {
@@ -378,7 +378,7 @@ byte AES::encrypt (byte plain [N_BLOCK], byte cipher [N_BLOCK])
 
 /******************************************************************************/
 
-byte AES::cbc_encrypt (byte * plain, byte * cipher, int n_block, byte iv [N_BLOCK])
+byte AES::cbc_encrypt (const byte * plain, byte * cipher, int n_block, byte iv [N_BLOCK])
 {
   while (n_block--)
     {
@@ -394,7 +394,7 @@ byte AES::cbc_encrypt (byte * plain, byte * cipher, int n_block, byte iv [N_BLOC
 
 /******************************************************************************/
 
-byte AES::cbc_encrypt (byte * plain, byte * cipher, int n_block)
+byte AES::cbc_encrypt (const byte * plain, byte * cipher, int n_block)
 {
   while (n_block--)
     {
@@ -410,7 +410,7 @@ byte AES::cbc_encrypt (byte * plain, byte * cipher, int n_block)
 
 /******************************************************************************/
 
-byte AES::decrypt (byte plain [N_BLOCK], byte cipher [N_BLOCK])
+byte AES::decrypt (const byte plain [N_BLOCK], byte cipher [N_BLOCK])
 {
   if (round)
     {
@@ -433,7 +433,7 @@ byte AES::decrypt (byte plain [N_BLOCK], byte cipher [N_BLOCK])
 
 /******************************************************************************/
 
-byte AES::cbc_decrypt (byte * cipher, byte * plain, int n_block, byte iv [N_BLOCK])
+byte AES::cbc_decrypt (const byte * cipher, byte * plain, int n_block, byte iv [N_BLOCK])
 {
   while (n_block--)
     {
@@ -451,7 +451,7 @@ byte AES::cbc_decrypt (byte * cipher, byte * plain, int n_block, byte iv [N_BLOC
 
 /******************************************************************************/
 
-byte AES::cbc_decrypt (byte * cipher, byte * plain, int n_block)
+byte AES::cbc_decrypt (const byte * cipher, byte * plain, int n_block)
 {
   while (n_block--)
     {
@@ -571,7 +571,7 @@ int AES::get_pad_len(int p_size){
 }
 
 /******************************************************************************/
-void AES::padPlaintext(void* in,byte* out)
+void AES::padPlaintext(const void* in,byte* out)
 {
   memcpy(out,in,size);
   for (int i = size-pad; i < size; i++){;
@@ -603,7 +603,7 @@ void AES::padPlaintext(void* in,byte* out)
 
 /******************************************************************************/
 
-int AES::get_unpadded_len(byte* msg,int p_size)
+int AES::get_unpadded_len(const byte* msg,int p_size)
 {
   byte pad_char = 0x00;
   int i = 0;
@@ -653,7 +653,7 @@ paddingMode AES::getPadMode(){
 
 /******************************************************************************/
 /// TODO check different modes
-bool AES::CheckPad(byte* in,int lsize){
+bool AES::CheckPad(const byte* in,int lsize){
   if (in[lsize-1] <= 0x0f){  //only block of less than 16 bytes are allowed
     int lpad = (int)in[lsize-1];
     for (int i = lsize - 1; i >= lsize-lpad; i--){
@@ -669,7 +669,7 @@ return true;
 
 /******************************************************************************/
 
-void AES::printArray(byte output[],bool p_pad)
+void AES::printArray(const byte output[],bool p_pad)
 {
 uint8_t i,j;
 uint8_t loops = size/N_BLOCK;
@@ -686,7 +686,7 @@ for (j = 0; j < loops; j += 1){
 
 /******************************************************************************/
 
-void AES::printArray(byte output[],int sizel)
+void AES::printArray(const byte output[],int sizel)
 {
   for (int i = 0; i < sizel; i++)
   {
@@ -698,7 +698,7 @@ void AES::printArray(byte output[],int sizel)
 
 /******************************************************************************/
 
-void AES::do_aes_encrypt(byte *plain,int size_p,byte *cipher,byte *key, int bits, byte ivl [N_BLOCK]){
+void AES::do_aes_encrypt(const byte *plain,int size_p,byte *cipher, const byte *key, int bits, byte ivl [N_BLOCK]){
   calc_size_n_pad(size_p);
   byte plain_p[get_size()];
   padPlaintext(plain,plain_p);
@@ -710,7 +710,7 @@ void AES::do_aes_encrypt(byte *plain,int size_p,byte *cipher,byte *key, int bits
 
 /******************************************************************************/
 
-void AES::do_aes_encrypt(byte *plain,int size_p,byte *cipher,byte *key, int bits){
+void AES::do_aes_encrypt(const byte *plain,int size_p,byte *cipher, const byte *key, int bits){
   calc_size_n_pad(size_p);
   byte plain_p[get_size()];
   padPlaintext(plain,plain_p);
@@ -721,7 +721,7 @@ void AES::do_aes_encrypt(byte *plain,int size_p,byte *cipher,byte *key, int bits
 
 /******************************************************************************/
 
-int AES::do_aes_decrypt(byte *cipher,int size_c,byte *plain,byte *key, int bits, byte ivl [N_BLOCK]){
+int AES::do_aes_decrypt(const byte *cipher,int size_c,byte *plain,const byte *key, int bits, byte ivl [N_BLOCK]){
   set_size(size_c);
   int blocks = size_c / N_BLOCK;
   set_key (key, bits);
@@ -731,7 +731,7 @@ int AES::do_aes_decrypt(byte *cipher,int size_c,byte *plain,byte *key, int bits,
 
 /******************************************************************************/
 
-int AES::do_aes_decrypt(byte *cipher,int size_c,byte *plain,byte *key, int bits){
+int AES::do_aes_decrypt(const byte *cipher,int size_c,byte *plain,const byte *key, int bits){
   set_size(size_c);
   int blocks = size_c / N_BLOCK;
   set_key (key, bits);

--- a/src/AES.h
+++ b/src/AES.h
@@ -74,7 +74,7 @@ class AES
    *  (valid inputs are hence 128, 192, 16, 24 and 32).
    *
    */
-  byte set_key (byte key[], uint16_t keylen) ;
+  byte set_key (const byte key[], uint16_t keylen) ;
 
   /** clean up subkeys after use.
    *
@@ -89,7 +89,7 @@ class AES
    *  i have not updated the function in the implementation yet, but it is considered a future plan.
    *
    */
-  void copy_n_bytes (byte * AESt, byte * src, byte n) ;
+  void copy_n_bytes (byte * AESt, const byte * src, byte n) ;
 
 
   /** get a random number
@@ -111,7 +111,7 @@ class AES
    *  @Return 0 if SUCCESS or -1 if FAILURE
    *
    */
-  byte encrypt (byte plain [N_BLOCK], byte cipher [N_BLOCK]) ;
+  byte encrypt (const byte plain [N_BLOCK], byte cipher [N_BLOCK]) ;
 
   /** CBC encrypt a number of blocks (input and return an IV).
    *
@@ -122,7 +122,7 @@ class AES
    *  @Return 0 if SUCCESS or -1 if FAILURE
    *
    */
-  byte cbc_encrypt (byte * plain, byte * cipher, int n_block, byte iv [N_BLOCK]) ;
+  byte cbc_encrypt (const byte * plain, byte * cipher, int n_block, byte iv [N_BLOCK]) ;
 
   /** CBC encrypt a number of blocks (input and return an IV).
    *
@@ -132,7 +132,7 @@ class AES
    *  @Return 0 if SUCCESS or -1 if FAILURE
    *
    */
-  byte cbc_encrypt (byte * plain, byte * cipher, int n_block) ;
+  byte cbc_encrypt (const byte * plain, byte * cipher, int n_block) ;
 
 
   /**  Decrypt a single block of 16 bytes
@@ -147,7 +147,7 @@ class AES
    *  @Return 0 if SUCCESS or -1 if FAILURE
    *
    */
-  byte decrypt (byte cipher [N_BLOCK], byte plain [N_BLOCK]) ;
+  byte decrypt (const byte cipher [N_BLOCK], byte plain [N_BLOCK]) ;
 
   /** CBC decrypt a number of blocks (input and return an IV)
    *
@@ -158,7 +158,7 @@ class AES
    *  @Return 0 if SUCCESS or -1 if FAILURE
    *
    */
-  byte cbc_decrypt (byte * cipher, byte * plain, int n_block, byte iv [N_BLOCK]) ;
+  byte cbc_decrypt (const byte * cipher, byte * plain, int n_block, byte iv [N_BLOCK]) ;
 
   /** CBC decrypt a number of blocks (input and return an IV)
    *
@@ -168,7 +168,7 @@ class AES
    *  @Return 0 if SUCCESS or -1 if FAILURE
    *
    */
-  byte cbc_decrypt (byte * cipher, byte * plain, int n_block) ;
+  byte cbc_decrypt (const byte * cipher, byte * plain, int n_block) ;
 
   /** Sets IV (initialization vector) and IVC (IV counter).
    *  This function changes the ivc and iv variables needed for AES.
@@ -234,7 +234,7 @@ class AES
    * @param in the array of the padded text
    * @param p_size the size of the byte array ex sizeof(paddedtext)
   */
-  int get_unpadded_len(byte *in , int p_size);
+  int get_unpadded_len(const byte *in , int p_size);
 
   /** returns the number of padding characters.
    *
@@ -256,7 +256,7 @@ class AES
    * @param out The string of the out array.
    * @return no return, The padded plaintext is stored in the out pointer.
    */
-  void padPlaintext(void* in,byte* out);
+  void padPlaintext(const void* in,byte* out);
 
   /** Check the if the padding is correct.
    *
@@ -266,7 +266,7 @@ class AES
    * @param size the size of the string
    * @return true if correct / false if not
    */
-  bool CheckPad(byte* in,int size);
+  bool CheckPad(const byte* in,int size);
 
   /** Sets the padding mode
    *
@@ -291,7 +291,7 @@ class AES
    * @param output[] the string of the text in a byte array
    * @param p_pad optional, used to print with out the padding characters
   */
-  void printArray(byte output[],bool p_pad = true);
+  void printArray(const byte output[],bool p_pad = true);
 
   /** Prints the array given.
    *
@@ -300,7 +300,7 @@ class AES
    * @param output[] the string of the text in a byte array
    * @param sizel the size of the array.
   */
-  void printArray(byte output[],int sizel);
+  void printArray(const byte output[],int sizel);
 
   /** User friendly implementation of AES-CBC encryption.
    *
@@ -312,7 +312,7 @@ class AES
    * @param ivl[N_BLOCK] the initialization vector IV that will be used for encryption.
    * @note The key will be stored in class variable.
    */
-  void do_aes_encrypt(byte *plain,int size_p,byte *cipher,byte *key, int bits, byte ivl [N_BLOCK]);
+  void do_aes_encrypt(const byte *plain,int size_p,byte *cipher,const byte *key,int bits, byte ivl [N_BLOCK]);
 
   /** User friendly implementation of AES-CBC encryption.
    *
@@ -323,7 +323,7 @@ class AES
    * @param bits bits of the encryption/decrpytion
    * @note The key will be stored in class variable.
    */
-  void do_aes_encrypt(byte *plain,int size_p,byte *cipher,byte *key, int bits);
+  void do_aes_encrypt(const byte *plain,int size_p,byte *cipher,const byte *key,int bits);
 
   /** User friendly implementation of AES-CBC decryption.
    *
@@ -335,7 +335,7 @@ class AES
    * @param ivl[N_BLOCK] the initialization vector IV that will be used for decryption.
    * @note The key will be stored in class variable.
    */
-  int do_aes_decrypt(byte *cipher,int size_c,byte *plain,byte *key, int bits, byte ivl [N_BLOCK]);
+  int do_aes_decrypt(const byte *cipher,int size_c,byte *plain,const byte *key, int bits, byte ivl [N_BLOCK]);
 
   /** User friendly implementation of AES-CBC decryption.
    *
@@ -346,7 +346,7 @@ class AES
    * @param bits bits of the encryption/decrpytion
    * @note The key will be stored in class variable.
    */
-  int do_aes_decrypt(byte *cipher,int size_c,byte *plain,byte *key, int bits);
+  int do_aes_decrypt(const byte *cipher,int size_c,byte *plain,const byte *key, int bits);
 
   #if defined(AES_LINUX)
     /**

--- a/src/AESLib.cpp
+++ b/src/AESLib.cpp
@@ -50,7 +50,7 @@ void AESLib::clean() {
 //
 
 /* Returns message encrypted only to be used as byte array. TODO: Refactor to byte[] */
-uint16_t AESLib::encrypt(byte input[], uint16_t input_length, char * output, byte key[], int bits, byte my_iv[]) {
+uint16_t AESLib::encrypt(const byte input[], uint16_t input_length, char * output, const byte key[], int bits, byte my_iv[]) {
 
   aes.set_key(key, bits);
   aes.setPadMode((paddingMode)0); // CMS, Bit, ZeroLength, Null, Space, Random, Array
@@ -91,7 +91,7 @@ uint16_t AESLib::encrypt(byte input[], uint16_t input_length, char * output, byt
 }
 
 /* Returns byte array decoded and decrypted. TODO: Refactor to byte[] */
-uint16_t AESLib::decrypt(byte input[], uint16_t input_length, char * plain, byte key[],int bits, byte my_iv[]) {
+uint16_t AESLib::decrypt(const byte input[], uint16_t input_length, char * plain, const byte key[],int bits, byte my_iv[]) {
   aes.set_key(key, bits);
   byte decode_buffer[input_length];
   uint16_t b64len = base64_decode((char*)decode_buffer, (char*)input, input_length);
@@ -176,7 +176,7 @@ String AESLib::encrypt(String msg, byte key[],int bits, byte my_iv[]) {
 //
 
 /* Returns message encrypted and base64 encoded to be used as string. */
-uint16_t AESLib::encrypt64(char * msg, uint16_t msgLen, char * output, byte key[],int bits, byte my_iv[]) {
+uint16_t AESLib::encrypt64(const char * msg, uint16_t msgLen, char * output, const byte key[],int bits, byte my_iv[]) {
 
   aes.set_key(key, bits);
 
@@ -197,7 +197,7 @@ uint16_t AESLib::encrypt64(char * msg, uint16_t msgLen, char * output, byte key[
 }
 
 /* Suggested size for the plaintext buffer is 1/2 length of `msg`. Refactor! */
-uint16_t AESLib::decrypt64(char * msg, uint16_t msgLen, char * plain, byte key[],int bits, byte my_iv[]) {
+uint16_t AESLib::decrypt64(char * msg, uint16_t msgLen, char * plain, const byte key[],int bits, byte my_iv[]) {
 
 #ifdef AES_DEBUG
   Serial.println("[decrypt64] decrypting message:  ");

--- a/src/AESLib.h
+++ b/src/AESLib.h
@@ -48,11 +48,11 @@ class AESLib
     void set_paddingmode(paddingMode mode);
     paddingMode get_paddingmode();
 
-    uint16_t encrypt64(char * input, uint16_t input_length, char * output, byte key[],int bits, byte my_iv[]); // base64 encode, encrypt and base64 encode again; will deprecate
-    uint16_t encrypt(byte input[], uint16_t input_length, char * output, byte key[],int bits, byte my_iv[]); // base64 encode and encrypt; should encode on output only (if)
+    uint16_t encrypt64(const char * input, uint16_t input_length, char * output, const byte key[],int bits, byte my_iv[]); // base64 encode, encrypt and base64 encode again; will deprecate
+    uint16_t encrypt(const byte input[], uint16_t input_length, char * output, const byte key[],int bits, byte my_iv[]); // base64 encode and encrypt; should encode on output only (if)
 
-    uint16_t decrypt64(char * input, uint16_t input_length, char * output, byte key[],int bits, byte my_iv[]); // decode, decrypt and decode
-    uint16_t decrypt(byte input[], uint16_t input_length, char * output, byte key[], int bits, byte my_iv[]); // decrypts and decodes (expects encoded)
+    uint16_t decrypt64(char * input, uint16_t input_length, char * output, const byte key[],int bits, byte my_iv[]); // decode, decrypt and decode
+    uint16_t decrypt(const byte input[], uint16_t input_length, char * output, const byte key[], int bits, byte my_iv[]); // decrypts and decodes (expects encoded)
 
 #ifndef __AVR__
     std::string intToHex(uint8_t intValue);

--- a/src/base64.cpp
+++ b/src/base64.cpp
@@ -16,11 +16,11 @@ const char PROGMEM b64_alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     "0123456789+/";
 
 /* 'Private' declarations */
-inline void a3_to_a4(unsigned char * a4, unsigned char * a3);
-inline void a4_to_a3(unsigned char * a3, unsigned char * a4);
+inline void a3_to_a4(unsigned char * a4, const unsigned char * a3);
+inline void a4_to_a3(unsigned char * a3, const unsigned char * a4);
 inline unsigned char b64_lookup(char c);
 
-int base64_encode(char *output, char *input, int inputLen) {
+int base64_encode(char *output, const char *input, int inputLen) {
   int i = 0, j = 0;
   int encLen = 0;
   unsigned char a3[3];
@@ -66,7 +66,7 @@ int base64_encode(char *output, char *input, int inputLen) {
   return encLen;
 }
 
-int base64_decode(char * output, char * input, int inputLen) {
+int base64_decode(char * output, const char * input, int inputLen) {
   int i = 0, j = 0;
   int decLen = 0;
   unsigned char a3[3];
@@ -117,7 +117,7 @@ int base64_enc_len(int plainLen) {
   return (n + 2 - ((n + 2) % 3)) / 3 * 4;
 }
 
-int base64_dec_len(char * input, int inputLen) {
+int base64_dec_len(const char * input, int inputLen) {
   int i = 0;
   int numEq = 0;
   for(i = inputLen - 1; input[i] == '='; i--) {
@@ -127,14 +127,14 @@ int base64_dec_len(char * input, int inputLen) {
   return ((6 * inputLen) / 8) - numEq;
 }
 
-inline void a3_to_a4(unsigned char * a4, unsigned char * a3) {
+inline void a3_to_a4(unsigned char * a4, const unsigned char * a3) {
   a4[0] = (a3[0] & 0xfc) >> 2;
   a4[1] = ((a3[0] & 0x03) << 4) + ((a3[1] & 0xf0) >> 4);
   a4[2] = ((a3[1] & 0x0f) << 2) + ((a3[2] & 0xc0) >> 6);
   a4[3] = (a3[2] & 0x3f);
 }
 
-inline void a4_to_a3(unsigned char * a3, unsigned char * a4) {
+inline void a4_to_a3(unsigned char * a3, const unsigned char * a4) {
   a3[0] = (a4[0] << 2) + ((a4[1] & 0x30) >> 4);
   a3[1] = ((a4[1] & 0xf) << 4) + ((a4[2] & 0x3c) >> 2);
   a3[2] = ((a4[2] & 0x3) << 6) + a4[3];

--- a/src/base64.h
+++ b/src/base64.h
@@ -26,7 +26,7 @@ extern const char b64_alphabet[];
  *      2. input must not be null
  *      3. inputLen must be greater than or equal to 0
  */
-int base64_encode(char *output, char *input, int inputLen);
+int base64_encode(char *output, const char *input, int inputLen);
 
 /* base64_decode:
  *    Description:
@@ -44,7 +44,7 @@ int base64_encode(char *output, char *input, int inputLen);
  *      2. input must not be null
  *      3. inputLen must be greater than or equal to 0
  */
-int base64_decode(char *output, char *input, int inputLen);
+int base64_decode(char *output, const char *input, int inputLen);
 
 /* base64_enc_len:
  *    Description:
@@ -74,6 +74,6 @@ int base64_enc_len(int inputLen);
  *      1. input must not be null
  *      2. input must be greater than or equal to zero
  */
-int base64_dec_len(char *input, int inputLen);
+int base64_dec_len(const char *input, int inputLen);
 
 #endif // _BASE64_H


### PR DESCRIPTION
The library is not using `const` on pointers, making it hard to guess which buffers are overwritten and which are safe.

This PR adds `const` specifiers to the methods that do not alter the input buffers.