### PR TITLE
More optimizations by reusing input buffer

### DIFF
--- a/src/AESLib.cpp
+++ b/src/AESLib.cpp
@@ -91,24 +91,23 @@ uint16_t AESLib::encrypt(const byte input[], uint16_t input_length, char * outpu
 }
 
 /* Returns byte array decoded and decrypted. TODO: Refactor to byte[] */
-uint16_t AESLib::decrypt(const byte input[], uint16_t input_length, char * plain, const byte key[],int bits, byte my_iv[]) {
-  aes.set_key(key, bits);
-  byte decode_buffer[input_length];
-  uint16_t b64len = base64_decode((char*)decode_buffer, (char*)input, input_length);
+uint16_t AESLib::decrypt(byte input[], uint16_t input_length, char * plain, const byte key[], int bits, byte my_iv[]) {
+  byte * decode_input = input;
+  uint16_t b64len = base64_decode((char*)decode_input, (char*)input, input_length);
 
 #ifndef __x86_64
 #ifndef __AVR__
 #ifdef AES_DEBUG
   Serial.printf("[AESLib::decrypt] Decoded bytes = ");
   for (uint8_t pos = 0; pos < b64len; pos++) {
-    Serial.printf("%s ", intToHex(decode_buffer[pos]).c_str());
+    Serial.printf("%s ", intToHex(decode_input[pos]).c_str());
   }
   Serial.printf("\n");
 #endif
 #endif
 #endif
 
-  int dec_len = aes.do_aes_decrypt((byte *)decode_buffer, b64len, (byte*)plain, key, bits, (byte *)my_iv);
+  int dec_len = aes.do_aes_decrypt((byte *)decode_input, b64len, (byte *)plain, key, bits, (byte *)my_iv);
 
   return dec_len;
 }

--- a/src/AESLib.h
+++ b/src/AESLib.h
@@ -52,7 +52,7 @@ class AESLib
     uint16_t encrypt(const byte input[], uint16_t input_length, char * output, const byte key[],int bits, byte my_iv[]); // base64 encode and encrypt; should encode on output only (if)
 
     uint16_t decrypt64(char * input, uint16_t input_length, char * output, const byte key[],int bits, byte my_iv[]); // decode, decrypt and decode
-    uint16_t decrypt(const byte input[], uint16_t input_length, char * output, const byte key[], int bits, byte my_iv[]); // decrypts and decodes (expects encoded)
+    uint16_t decrypt(byte input[], uint16_t input_length, char * output, const byte key[], int bits, byte my_iv[]); // decrypts and decodes (expects encoded)
 
 #ifndef __AVR__
     std::string intToHex(uint8_t intValue);


### PR DESCRIPTION
Removed aes.set_key() function from the decrypt(), since set_size() called from do_aes_decrypt