### PR TITLE
Conditional directive for ESP32 on gen_iv method to correctly randomize the values

### DIFF
--- a/src/AESLib.cpp
+++ b/src/AESLib.cpp
@@ -29,8 +29,8 @@ void AESLib::gen_iv(uint8_t * iv) {
         esp_fill_random(iv, N_BLOCK);
     #else
         for (int i = 0 ; i < N_BLOCK ; i++ ) {
-        iv[i]= getrnd();
-    }
+            iv[i]= getrnd();
+        }
     #endif
 }
 

--- a/src/AESLib.cpp
+++ b/src/AESLib.cpp
@@ -25,9 +25,13 @@ uint8_t AESLib::getrnd()
 }
 
 void AESLib::gen_iv(uint8_t * iv) {
-    for (int i = 0 ; i < N_BLOCK ; i++ ) {
+    #ifdef ARDUINO_ARCH_ESP32
+        esp_fill_random(iv, N_BLOCK);
+    #else
+        for (int i = 0 ; i < N_BLOCK ; i++ ) {
         iv[i]= getrnd();
     }
+    #endif
 }
 
 void AESLib::set_paddingmode(paddingMode mode){


### PR DESCRIPTION
Added a conditional directive into gen_iv method to identify if the board is an ESP32. If so, use esp_fill_random method to initialize iv.